### PR TITLE
Add more tests (caching, format...)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,9 +9,6 @@ const image = require('./routes/image');
 
 const app = express();
 
-// setup cache folder
-fileCache.init();
-
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');

--- a/app.js
+++ b/app.js
@@ -2,8 +2,6 @@ const express = require('express');
 const path = require('path');
 const logger = require('morgan');
 
-const fileCache = require('./middleware/fileCache');
-
 const index = require('./routes/index');
 const image = require('./routes/image');
 

--- a/controllers/convert.js
+++ b/controllers/convert.js
@@ -19,20 +19,16 @@ function convert(req, res, next) {
 
   // auto best format detection
   if (format === undefined) {
-    let accept = req.get('accept');
-    if (/image\/webp/.test(accept)) {
-      format = sharp.format['webp'];
+    // if webp is accepted, it is set before checking the cache
+    if (req.imageProperties.hasAlpha) {
+      format = sharp.format['png'];
     } else {
-      if (sharpInstance.hasAlpha) {
-        format = sharp.format['png'];
-      } else {
-        format = sharp.format['jpeg'];
-      }
+      format = sharp.format['jpeg'];
     }
   }
 
   // format conversion & set response type
-  if (format.id !== req.imageProperties.type) {
+  if (format.id !== req.imageProperties.format) {
     sharpInstance
       .toFormat(format, options);
   }

--- a/middleware/checkCache.js
+++ b/middleware/checkCache.js
@@ -17,13 +17,13 @@ function checkCache(req, res, next) {
       .metadata()
       .then((metadata) => {
         req.imageProperties = metadata;
-        res.type(metadata.type);
+        res.type(metadata.format);
         res.set('Etag', queryHash);
         req.completed = true;
         return next();
       })
-      .catch(() => {
-        console.error('error loading file from cache', queryHash);
+      .catch((error) => {
+        console.error('error loading file from cache', queryHash, error);
         cache.remove(queryHash);
         return next();
       });

--- a/middleware/checkCache.js
+++ b/middleware/checkCache.js
@@ -1,6 +1,6 @@
 const cache = require('../middleware/fileCache');
 const hash = require('object-hash');
-const probe = require('probe-image-size');
+const sharp = require('sharp');
 
 function checkCache(req, res, next) {
   // generate hash and check if image exists in cache
@@ -9,20 +9,26 @@ function checkCache(req, res, next) {
     req.query.format = 'webp';
   }
 
-  let queryHash = hash(req.query);
+  const queryHash = hash(req.query);
 
   if (cache.exists(queryHash)) {
     req.image = cache.load(queryHash);
-    req.imageProperties = probe.sync(req.image);
-    if (!req.imageProperties) {
-      console.error('error loading file from cache', queryHash);
-      cache.remove(queryHash);
-    } else {
-      res.type(req.imageProperties.type);
-      res.set('Etag', queryHash);
-      req.completed = true;
-    }
+    return sharp(req.image)
+      .metadata()
+      .then((metadata) => {
+        req.imageProperties = metadata;
+        res.type(metadata.type);
+        res.set('Etag', queryHash);
+        req.completed = true;
+        return next();
+      })
+      .catch(() => {
+        console.error('error loading file from cache', queryHash);
+        cache.remove(queryHash);
+        return next();
+      });
   }
+
   return next();
 }
 

--- a/middleware/fileCache.js
+++ b/middleware/fileCache.js
@@ -1,33 +1,42 @@
 const fs = require('fs');
 const config = require('config');
 
-let filepath = config.get('Caching.Imagepath');
-
-fileCache = {
-  init: function () {
-    if (!fs.existsSync(filepath)) {
-      fs.mkdir(filepath);
+class FileCache {
+  constructor() {
+    this.filePath = config.get('Caching.Imagepath');
+    if (!fs.existsSync(this.filePath)) {
+      fs.mkdir(this.filePath);
     }
-  },
-  add: function (filename, format, data) {
-    fs.writeFile(filepath + filename, data, function (err) {
+  }
+
+  add(filename, format, data) {
+    fs.writeFile(this.filePath + filename, data, function (err) {
       if (err) {
         console.log(err);
       }
     });
-  },
-  load: function (hash) {
-    return fs.readFileSync(filepath + hash);
-  },
-  exists: function (hash) {
-    return fs.existsSync(filepath + hash);
-  },
-  remove: function (hash) {
-    if (fs.existsSync(filepath + hash)) {
-      return fs.unlinkSync(filepath + hash);
-    } else {
-      return false;
+  }
+
+  load(hash) {
+    return fs.readFileSync(this.filePath + hash);
+  }
+
+  exists(hash) {
+    return fs.existsSync(this.filePath + hash);
+  }
+
+  remove(hash) {
+    if (fs.existsSync(this.filePath + hash)) {
+      return fs.unlinkSync(this.filePath + hash);
     }
-  },
-};
-module.exports = fileCache;
+    return false;
+  }
+
+  clear() {
+    fs.readdir(this.filePath, (err, files) => {
+      files.forEach(each => this.remove(each));
+    });
+  }
+}
+
+module.exports = new FileCache();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-es-beautifier": "^1.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.4.1",
-    "nodemon": "^1.11.0"
+    "nodemon": "^1.11.0",
+    "sinon": "~2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "config": "~1.26.1",
     "http-errors": "~1.6.1",
     "morgan": "~1.8.1",
-    "probe-image-size": "~3.0.0",
     "object-hash": "1.1.8",
     "pug": "~2.0.0-rc.1",
     "sharp": "~0.17.3"

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,24 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const server = require('../app.js');
+
+chai.should();
+chai.use(chaiHttp);
+
+describe('Cache', () => {
+  it('should return cached image for etag', (done) => {
+    chai.request(server)
+      .get('/image?url=https://http.cat/400')
+      .end((err, res) => {
+        res.status.should.equal(200);
+        chai.request(server)
+          .get('/image?url=https://http.cat/400')
+          .set('If-None-Match', res.headers.etag)
+          .end((err, res) => {
+            res.status.should.equal(304);
+            done();
+          });
+      });
+  });
+});
+

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,12 +1,43 @@
 const chai = require('chai');
 const chaiHttp = require('chai-http');
+const config = require('config');
+const fs = require('fs');
 const server = require('../app.js');
 
 chai.should();
 chai.use(chaiHttp);
 
 describe('Cache', () => {
-  it('should return cached image for etag', (done) => {
+  it('should cache the requested image', (done) => {
+    chai.request(server)
+      .get('/image?url=https://http.cat/400')
+      .end((err, res) => {
+        res.status.should.equal(200);
+        const filePath = config.get('Caching.Imagepath') + res.headers.etag;
+        fs.exists(filePath, (exists) => {
+          exists.should.be.true;
+          done();
+        });
+      });
+  });
+
+  it('should return same etag for same image', (done) => {
+    chai.request(server)
+      .get('/image?url=https://http.cat/400')
+      .end((err, res) => {
+        res.status.should.equal(200);
+        const etag = res.headers.etag;
+        chai.request(server)
+          .get('/image?url=https://http.cat/400')
+          .end((err, res) => {
+            res.status.should.equal(200);
+            etag.should.equal(res.headers.etag);
+            done();
+          });
+      });
+  });
+
+  it('should return status 304 for etag', (done) => {
     chai.request(server)
       .get('/image?url=https://http.cat/400')
       .end((err, res) => {

--- a/test/image.js
+++ b/test/image.js
@@ -268,6 +268,17 @@ describe('Image Controller', () => {
           done();
         });
     });
+
+    it('should return the image as webp automatically, if accepted', (done) => {
+      chai.request(server)
+        .get('/image?url=https://http.cat/100')
+        .set('Accept', 'image/webp')
+        .end((err, res) => {
+          res.status.should.equal(200);
+          res.headers['content-type'].should.equal('image/webp');
+          done();
+        });
+    });
   });
 
   it('should render the test interface', (done) => {

--- a/test/image.js
+++ b/test/image.js
@@ -269,6 +269,16 @@ describe('Image Controller', () => {
         });
     });
 
+    it('should return the image as png automatically, if it has an alpha channel', (done) => {
+      chai.request(server)
+        .get('/image?url=https://www.sarasoueidan.com/images/svg-vs-gif--circle-on-transparent-background.gif')
+        .end((err, res) => {
+          res.status.should.equal(200);
+          res.headers['content-type'].should.equal('image/png');
+          done();
+        });
+    });
+
     it('should return the image as webp automatically, if accepted', (done) => {
       chai.request(server)
         .get('/image?url=https://http.cat/100')


### PR DESCRIPTION
Feel free to contribute... ;)

Fixes an error detecting the alpha channel.
This also removes the `probe-image-size` dependency and uses `sharp.metadata()` instead.